### PR TITLE
feat: add Args::new() constructor for library/API use

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -58,6 +58,27 @@ impl Args {
     pub fn parse() -> Result<Self, clap::Error> {
         Self::try_parse()
     }
+
+    /// Create Args directly (for API/library use).
+    pub fn new(
+        old: PathBuf,
+        new: PathBuf,
+        key: Option<String>,
+        threshold: f64,
+        tolerance: f64,
+        delimiter: Option<u8>,
+        json: bool,
+    ) -> Self {
+        Self {
+            old,
+            new,
+            key,
+            threshold,
+            tolerance,
+            delimiter,
+            json,
+        }
+    }
 }
 
 fn parse_threshold(raw: &str) -> Result<f64, String> {


### PR DESCRIPTION
Adds a constructor for programmatic Args creation without CLI parsing.

Needed for [rvl-kovrex](https://github.com/cmdrvl/rvl-kovrex) and other wrappers that use rvl as a library.

```rust
let args = Args::new(
    PathBuf::from("old.csv"),
    PathBuf::from("new.csv"),
    Some("id".to_string()),  // key
    0.95,                      // threshold
    1e-9,                      // tolerance
    None,                      // delimiter
    true,                      // json
);
```